### PR TITLE
fix: Flag assert.equal in module hooks

### DIFF
--- a/lib/rules/no-assert-equal.js
+++ b/lib/rules/no-assert-equal.js
@@ -159,6 +159,41 @@ module.exports = {
             });
         }
 
+        /**
+         * @param {import('eslint').Rule.Node} propertyNode
+         * @returns {boolean}
+         */
+        function isModuleHookCallback(node) {
+            return (
+                node.parent &&
+                node.parent.type === "Property" &&
+                utils.isModuleHookPropertyKey(node.parent.key) &&
+                utils.isInModule(node.parent)
+            );
+        }
+
+        /**
+         * @param {import('eslint').Rule.Node} propertyNode
+         * @returns {boolean}
+         */
+        function pushModuleHookAssert(node) {
+            if (isModuleHookCallback(node)) {
+                testStack.push({
+                    assertVar: utils.getAssertContextName(node),
+                });
+            }
+        }
+
+        /**
+         * @param {import('eslint').Rule.Node} propertyNode
+         * @returns {boolean}
+         */
+        function popModuleHookAssert(node) {
+            if (isModuleHookCallback(node)) {
+                testStack.pop();
+            }
+        }
+
         return {
             CallExpression: function (node) {
                 /* istanbul ignore else: correctly does nothing */
@@ -188,6 +223,15 @@ module.exports = {
                     testStack.pop();
                 }
             },
+
+            FunctionDeclaration: pushModuleHookAssert,
+            FunctionExpression: pushModuleHookAssert,
+            ArrowFunctionExpression: pushModuleHookAssert,
+
+            "FunctionDeclaration:exit": popModuleHookAssert,
+            "FunctionExpression:exit": popModuleHookAssert,
+            "ArrowFunctionExpression:exit": popModuleHookAssert,
+
             Program: function (node) {
                 // Gather all calls to global `equal()`.
                 /* istanbul ignore next: deprecated code paths only followed by old eslint versions */

--- a/lib/rules/no-qunit-start-in-tests.js
+++ b/lib/rules/no-qunit-start-in-tests.js
@@ -51,20 +51,6 @@ module.exports = {
             );
         }
 
-        /**
-         * @param {import('eslint').Rule.Node} propertyNode
-         * @returns {boolean}
-         */
-        function isInModule(propertyNode) {
-            return (
-                propertyNode &&
-                propertyNode.parent && // ObjectExpression
-                propertyNode.parent.parent && // CallExpression?
-                propertyNode.parent.parent.type === "CallExpression" &&
-                utils.isModule(propertyNode.parent.parent.callee)
-            );
-        }
-
         //----------------------------------------------------------------------
         // Public
         //----------------------------------------------------------------------
@@ -93,7 +79,7 @@ module.exports = {
             Property: function (node) {
                 if (
                     utils.isModuleHookPropertyKey(node.key) &&
-                    isInModule(node) &&
+                    utils.isInModule(node) &&
                     node.key.type === "Identifier"
                 ) {
                     contextStack.push(`${node.key.name} hook`);
@@ -109,7 +95,7 @@ module.exports = {
             "Property:exit": function (node) {
                 if (
                     utils.isModuleHookPropertyKey(node.key) &&
-                    isInModule(node)
+                    utils.isInModule(node)
                 ) {
                     contextStack.pop();
                 }

--- a/lib/rules/no-setup-teardown.js
+++ b/lib/rules/no-setup-teardown.js
@@ -68,25 +68,11 @@ module.exports = {
             }
         }
 
-        /**
-         * @param {import('eslint').Rule.Node} propertyNode
-         * @returns {boolean}
-         */
-        function isInModule(propertyNode) {
-            return (
-                propertyNode &&
-                propertyNode.parent && // ObjectExpression
-                propertyNode.parent.parent && // CallExpression?
-                propertyNode.parent.parent.type === "CallExpression" &&
-                utils.isModule(propertyNode.parent.parent.callee)
-            );
-        }
-
         return {
             Property: function (node) {
                 if (
                     utils.isModuleHookPropertyKey(node.key) &&
-                    isInModule(node)
+                    utils.isInModule(node)
                 ) {
                     checkModuleHook(node);
                 }

--- a/lib/rules/resolve-async.js
+++ b/lib/rules/resolve-async.js
@@ -159,20 +159,6 @@ module.exports = {
             }
         }
 
-        /**
-         * @param {import('eslint').Rule.Node} propertyNode
-         * @returns {boolean}
-         */
-        function isInModule(propertyNode) {
-            return (
-                propertyNode &&
-                propertyNode.parent && // ObjectExpression
-                propertyNode.parent.parent && // CallExpression?
-                propertyNode.parent.parent.type === "CallExpression" &&
-                utils.isModule(propertyNode.parent.parent.callee)
-            );
-        }
-
         return {
             CallExpression: function (node) {
                 const callbackVar = getAsyncCallbackVarOrNull(node.callee);
@@ -213,7 +199,7 @@ module.exports = {
             Property: function (node) {
                 if (
                     utils.isModuleHookPropertyKey(node.key) &&
-                    isInModule(node)
+                    utils.isInModule(node)
                 ) {
                     asyncStateStack.push({
                         stopSemaphoreCount: 0,
@@ -228,7 +214,7 @@ module.exports = {
             "Property:exit": function (node) {
                 if (
                     utils.isModuleHookPropertyKey(node.key) &&
-                    isInModule(node)
+                    utils.isInModule(node)
                 ) {
                     const asyncState = asyncStateStack.pop();
                     if (!asyncState) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,12 @@ const assert = require("node:assert");
 const SUPPORTED_TEST_IDENTIFIERS = new Set(["test", "asyncTest", "only"]);
 
 const OLD_MODULE_HOOK_IDENTIFIERS = ["setup", "teardown"];
-const NEW_MODULE_HOOK_IDENTIFIERS = ["beforeEach", "afterEach"];
+const NEW_MODULE_HOOK_IDENTIFIERS = [
+    "before",
+    "beforeEach",
+    "afterEach",
+    "after",
+];
 const ALL_MODULE_HOOK_IDENTIFIERS = new Set([
     ...OLD_MODULE_HOOK_IDENTIFIERS,
     ...NEW_MODULE_HOOK_IDENTIFIERS,
@@ -214,6 +219,20 @@ exports.isModule = function (calleeNode) {
     }
 
     return result;
+};
+
+/**
+ * @param {import('eslint').Rule.Node} propertyNode
+ * @returns {boolean}
+ */
+exports.isInModule = function (propertyNode) {
+    return (
+        propertyNode &&
+        propertyNode.parent && // ObjectExpression
+        propertyNode.parent.parent && // CallExpression?
+        propertyNode.parent.parent.type === "CallExpression" &&
+        this.isModule(propertyNode.parent.parent.callee)
+    );
 };
 
 /**

--- a/tests/lib/rules/no-arrow-tests.js
+++ b/tests/lib/rules/no-arrow-tests.js
@@ -189,6 +189,26 @@ ruleTester.run("no-arrow-tests", rule, {
             ],
         },
         {
+            code: "QUnit.module('module', { before: () => {} });",
+            output: "QUnit.module('module', { before: function() {} });",
+            errors: [
+                {
+                    messageId: "noArrowFunction",
+                    type: "ArrowFunctionExpression",
+                },
+            ],
+        },
+        {
+            code: "QUnit.module('module', { after: () => {} });",
+            output: "QUnit.module('module', { after: function() {} });",
+            errors: [
+                {
+                    messageId: "noArrowFunction",
+                    type: "ArrowFunctionExpression",
+                },
+            ],
+        },
+        {
             code: "module('module', { setup: () => {} });",
             output: "module('module', { setup: function() {} });",
             errors: [

--- a/tests/lib/rules/no-assert-equal.js
+++ b/tests/lib/rules/no-assert-equal.js
@@ -184,5 +184,30 @@ ruleTester.run("no-assert-equal", rule, {
                 },
             ],
         },
+        {
+            // assert.equal in module hooks
+            code: "QUnit.module('My module', { before: function (assert) { assert.equal(1, 1); } });",
+            parser: require.resolve("@typescript-eslint/parser"),
+            errors: [
+                {
+                    messageId: "unexpectedAssertEqual",
+                    data: { assertVar: "assert" },
+                    suggestions: [
+                        {
+                            messageId: "switchToDeepEqual",
+                            output: "QUnit.module('My module', { before: function (assert) { assert.deepEqual(1, 1); } });",
+                        },
+                        {
+                            messageId: "switchToPropEqual",
+                            output: "QUnit.module('My module', { before: function (assert) { assert.propEqual(1, 1); } });",
+                        },
+                        {
+                            messageId: "switchToStrictEqual",
+                            output: "QUnit.module('My module', { before: function (assert) { assert.strictEqual(1, 1); } });",
+                        },
+                    ],
+                },
+            ],
+        },
     ],
 });

--- a/tests/lib/rules/no-qunit-start-in-tests.js
+++ b/tests/lib/rules/no-qunit-start-in-tests.js
@@ -58,6 +58,14 @@ ruleTester.run("no-qunit-start-in-tests", rule, {
             errors: [createError("afterEach hook")],
         },
         {
+            code: 'QUnit.module("module", { before: function() { QUnit.start(); } });',
+            errors: [createError("before hook")],
+        },
+        {
+            code: 'QUnit.module("module", { after: function() { QUnit.start(); } });',
+            errors: [createError("after hook")],
+        },
+        {
             code: 'QUnit.module("module", { setup: function() { QUnit.start(); } });',
             errors: [createError("setup hook")],
         },

--- a/tests/lib/rules/no-setup-teardown.js
+++ b/tests/lib/rules/no-setup-teardown.js
@@ -29,8 +29,14 @@ ruleTester.run("no-setup-teardown", rule, {
         // afterEach
         "QUnit.module('Module', { afterEach: function () {} });",
 
-        // both
-        "QUnit.module('Module', { beforeEach: function () {}, afterEach: function () {} });",
+        // before
+        "QUnit.module('Module', { before: function () {} });",
+
+        // after
+        "QUnit.module('Module', { after: function () {} });",
+
+        // all
+        "QUnit.module('Module', { before: function () {}, beforeEach: function () {}, afterEach: function () {}, after: function () {} });",
 
         // other property names are not reported
         "QUnit.module('Module', { foo: function () {} });",

--- a/tests/lib/rules/resolve-async.js
+++ b/tests/lib/rules/resolve-async.js
@@ -196,11 +196,19 @@ ruleTester.run("resolve-async", rule, {
             errors: [createNeedStartCallsMessage("Property")],
         },
         {
+            code: "QUnit.module('name', { before: function () { QUnit.stop(); } });",
+            errors: [createNeedStartCallsMessage("Property")],
+        },
+        {
             code: "QUnit.module('name', { beforeEach: function () { QUnit.stop(); } });",
             errors: [createNeedStartCallsMessage("Property")],
         },
         {
             code: "QUnit.module('name', { afterEach: function () { QUnit.stop(); } });",
+            errors: [createNeedStartCallsMessage("Property")],
+        },
+        {
+            code: "QUnit.module('name', { after: function () { QUnit.stop(); } });",
             errors: [createNeedStartCallsMessage("Property")],
         },
 


### PR DESCRIPTION
- Updated no-assert-equal rule to also catch `assert.equal` in module hooks
- Moved `isInModule` into `utils` (was duplicated around a few places)
- Added `before` and `after` to recognized module hook properties
- Added test case

Fixes #531