### PR TITLE
chore: ignore dist/ for nyc test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "branches": 90,
     "exclude": [
       "build/**",
+      "dist/**",
       "eslint-remote-tester.config.js",
       "eslint.config.js",
       "scripts/**",


### PR DESCRIPTION
This was causing low coverage numbers.