### PR TITLE
fix: no-hooks-from-ancestor-modules in function contexts

### DIFF
--- a/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/lib/rules/no-hooks-from-ancestor-modules.js
@@ -120,17 +120,19 @@ module.exports = {
                     if (node.arguments.length === 0) {
                         return;
                     }
-                    if (
-                        node.arguments[0].type !== "Literal" ||
-                        node.arguments[0].value === null ||
-                        node.arguments[0].value === undefined
-                    ) {
-                        return;
+
+                    let description;
+                    if (node.arguments[0].type === "Literal") {
+                        description = node.arguments[0].value.toString();
+                    } else {
+                        const sourceCode = context.getSourceCode();
+                        description = sourceCode.getText(node.arguments[0]);
                     }
+
                     /** @type {{callExpression: import('eslint').Rule.Node, description: string, hookIdentifierName?: string | null}} */
                     const moduleStackInfo = {
                         callExpression: node,
-                        description: node.arguments[0].value.toString(),
+                        description: description,
                     };
                     const callback = getCallbackArg(node.arguments);
                     if (

--- a/tests/lib/rules/no-hooks-from-ancestor-modules.js
+++ b/tests/lib/rules/no-hooks-from-ancestor-modules.js
@@ -131,6 +131,13 @@ ruleTester.run("no-hooks-from-ancestor-modules", rule, {
             });
         });
         `,
+        `
+        function foo(name) {
+            QUnit.module(name, function (hooks) {
+                hooks.beforeEach(function () {});
+            });
+        }
+        `,
 
         {
             // TypeScript: module callback is adding a type to `this`
@@ -298,6 +305,24 @@ ruleTester.run("no-hooks-from-ancestor-modules", rule, {
             errors: [
                 createError({
                     invokedMethodName: "afterEach",
+                    usedHooksIdentifierName: "hooks",
+                }),
+            ],
+        },
+
+        {
+            code: `
+                function foo(name) {
+                    QUnit.module(\`\${name} parent\`, function (hooks) {
+                        QUnit.module(name, function () {
+                            hooks.beforeEach(function () {});
+                        });
+                    });
+                }
+            `,
+            errors: [
+                createError({
+                    invokedMethodName: "beforeEach",
                     usedHooksIdentifierName: "hooks",
                 }),
             ],


### PR DESCRIPTION
Fixes an error:

```
TypeError: Cannot read properties of undefined (reading 'hookIdentifierName')
```